### PR TITLE
run release job on push to main

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,12 @@
 name: Release Charts
 
 on:
+  # run release job when changes are pushed to main
+  # chart-releaser will only cut release when changes are detected
+  # hence a tag push will not trigger chart release
   push:
-    tags:
-      - '*'
+    branches:
+      - main
 
 permissions:  # added using https://github.com/step-security/secure-repo
   contents: read


### PR DESCRIPTION
Workaround the fact that chart-releaser will only work when there are changes with the triggered event - e.g. merge to main.
Hence pushing a tag won't work.