### PR TITLE
add name template to sampleData ingest job's configMap reference

### DIFF
--- a/charts/guac/templates/ingest-guac-data-job.yaml
+++ b/charts/guac/templates/ingest-guac-data-job.yaml
@@ -5,7 +5,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: ingest-guac-data
+  name: {{ .Values.guac.sampleData.jobName }}
   labels:
     {{- include "guac.labels" . | nindent 4 }}
     app.kubernetes.io/name: {{ .Values.guac.sampleData.jobName }}
@@ -56,7 +56,7 @@ spec:
             name: guac-cm
         - name: ingest-guac-data
           configMap:
-            name: ingest-guac-data
+            name: {{ .Values.guac.sampleData.jobName }}
             defaultMode: 0755
         - name: shared-data
           emptyDir: {}


### PR DESCRIPTION
This PR fix error when specify custom guac.sampleData.jobName, the job configmap's name is templated but the reference in job's spec is not.
Templated job name also for consistency