### PR TITLE
fix: updates s3 blob query parameters to keep up with gocloud updates

### DIFF
--- a/charts/guac/Chart.yaml
+++ b/charts/guac/Chart.yaml
@@ -9,8 +9,8 @@ maintainers:
     email: guac-info@kusari.dev
 
 type: application
-version: 0.5.1
-appVersion: "v0.8.0"
+version: 0.5.2
+appVersion: "v0.12.1"
 
 dependencies:
 - name: nats

--- a/charts/guac/templates/guac-cm.yaml
+++ b/charts/guac/templates/guac-cm.yaml
@@ -20,7 +20,7 @@ data:
 {{- if $.Values.guac.blobAddr }}
     blob-addr: {{ $.Values.guac.blobAddr }}
 {{- else }}
-    blob-addr: s3://bucketname?endpoint={{ .Release.Namespace }}-minio.{{ .Release.Namespace }}.svc.cluster.local:9000&region=us-east-1&disable_https=true&use_path_style=true
+    blob-addr: s3://bucketname?endpoint=http://{{ .Release.Namespace }}-minio.{{ .Release.Namespace }}.svc.cluster.local:9000&region=us-east-1&disable_https=true&use_path_style=true
 {{- end }}
     
 

--- a/charts/guac/templates/guac-cm.yaml
+++ b/charts/guac/templates/guac-cm.yaml
@@ -20,7 +20,7 @@ data:
 {{- if $.Values.guac.blobAddr }}
     blob-addr: {{ $.Values.guac.blobAddr }}
 {{- else }}
-    blob-addr: s3://bucketname?endpoint={{ .Release.Namespace }}-minio.{{ .Release.Namespace }}.svc.cluster.local:9000&region=us-east-1&disableSSL=true&s3ForcePathStyle=true
+    blob-addr: s3://bucketname?endpoint={{ .Release.Namespace }}-minio.{{ .Release.Namespace }}.svc.cluster.local:9000&region=us-east-1&disable_https=true&use_path_style=true
 {{- end }}
     
 


### PR DESCRIPTION
fixes: #59 

* replaces V1 query params with the corresponding V2 params
* fixes minio endpoint address
* updates chart and guac app versions