### PR TITLE
feat(guac): support for oci-collector extra volumes

### DIFF
--- a/charts/guac/templates/oci-collector-deployment.yaml
+++ b/charts/guac/templates/oci-collector-deployment.yaml
@@ -51,6 +51,9 @@ spec:
           - name: guac-config
             mountPath: {{ .Values.guac.guacImage.workingDir }}
             readOnly: true
+          {{- with .Values.guac.ociCollector.extraVolumeMounts }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
 
 {{- if or .Values.guac.common.env .Values.guac.ociCollector.env }}
         env:
@@ -70,6 +73,10 @@ spec:
         - name: guac-config
           configMap:
             name: guac-cm
+        {{- with .Values.guac.ociCollector.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+
 {{- if .Values.guac.ociCollector.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.guac.ociCollector.nodeSelector | indent 8 }}
@@ -85,5 +92,5 @@ spec:
 {{- end }}
 {{- end }}
 
-
 {{- end }}
+

--- a/charts/guac/values.yaml
+++ b/charts/guac/values.yaml
@@ -32,6 +32,8 @@ imagePullSecrets:
 ## @param guac.ociCollector.serviceAccount.create - whether to create OCI Collector service account
 ## @param guac.ociCollector.serviceAccount.annotations - OCI Collector service account annotations
 ## @param guac.ociCollector.resources - [map] resource requests or limits of the ociCollector deployment
+## @param guac.ociCollector.extraVolumeMounts - [map] extra volume mounts for the ociCollector deployment
+## @param guac.ociCollector.extraVolumes - [map] extra volumes for the ociCollector deployment
 ## @param guac.depsDevCollector.enabled String Whether to deploy Deps.Dev Collector
 ## @param guac.depsDevCollector.name String Name of the Deps.Dev Collector component.
 ## @param guac.depsDevCollector.annotations.reloader.stakater.com/auto [string] Boolean for deploying [stakater/Reloader] (https://github.com/stakater/Reloader)

--- a/charts/guac/values.yaml
+++ b/charts/guac/values.yaml
@@ -213,6 +213,16 @@ guac:
       # requests:
       #   cpu: "0.25"
       #   memory: "0.5G"
+    extraVolumeMounts: []
+      # Example: mount a secret read-only
+      # - name: reg-creds
+      #   mountPath: /var/run/registry-creds
+      #   readOnly: true
+    extraVolumes: []
+      # - name: reg-creds
+      #   secret:
+      #     secretName: my-registry-creds
+      #     optional: false
 
   depsDevCollector:
     enabled: true


### PR DESCRIPTION
## Description

Add support for adding extra volumes/volumeMounts to the `ociCollector` 

This allows secrets (at a minimum) to be mounted to the deployment such that the `ociCollector` can connect to private registries which require authentication.

If there are incorrect assumptions here please let me know. Given the specifics of the intent - I did not implement a general `common` option and instead scoped this only to the `ociCollector`.

## Issue

Fixes #68 